### PR TITLE
Adds failure checking on curl and dies on failure (e.g 404)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,12 @@ download_source_file() {
 
   echo $download_url
 
-  curl -Lo $download_path $download_url
+  curl --fail -Lo $download_path $download_url || die "error fetching $download_url"
+}
+
+die() {
+  echo $1
+  exit 1
 }
 
 


### PR DESCRIPTION
elm-lang.org was blocking my download with IP address filtering. This adds the `--fail` curl option and dies with a better message than one gets otherwise (a `tar` error). 