### PR TITLE
Allow alpha or rc releases, eg 0.18.0-alpha

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -11,7 +11,7 @@ if sort --help | grep -q -- '-V'; then
 fi
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE ':[0-9\.]+' | sed 's/://' | $sort_cmd)
+versions=$(eval $cmd | grep -oE ':[0-9\.]+(-\w+)?\/' | sed 's/://' | $sort_cmd)
 
 os=$(uname -s)
 


### PR DESCRIPTION
When you run `asdf list-all elm` now, you see 0.18.0 twice.  This is because for 0.18.0-alpha, the -alpha is cut of in the regex.