### PR TITLE
Support Elm releases on Github (including 0.19.0)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+bintray_versions='0.15.1 0.16.0 0.16 0.17.1 0.18.0 master'
 install_elm() {
   local install_type=$1
   local version=$2
@@ -19,7 +19,12 @@ install_elm() {
   # we don't want to disturb current working dir
   (
     mkdir -p $install_path/bin
-    tar zxf $source_path -C $install_path/bin --strip-components=1 || exit 1
+    if [[ " $bintray_versions " =~ " $version " ]]
+    then
+      tar zxf $source_path -C $install_path/bin --strip-components=1 || exit 1
+    else
+      tar zxf $source_path -C $install_path/bin || exit 1
+    fi
   )
 }
 
@@ -51,7 +56,7 @@ get_download_file_path() {
   echo "$tmp_download_dir/$pkg_name"
 }
 
-get_platform() {
+get_platform_pre_19() {
   local os=$(uname -s | tr '[A-Z]' '[a-z]')
 
   if [ "darwin" == "$os" ]; then
@@ -70,6 +75,25 @@ get_platform() {
   exit 1
 }
 
+get_platform_post_19() {
+  local os=$(uname -s | tr '[A-Z]' '[a-z]')
+
+  if [ "darwin" == "$os" ]; then
+    echo "mac"
+    return 0
+  fi
+
+  local machine=$(uname -m)
+  if [ "linux" == "$os" ]; then
+    echo "linux"
+    return 0
+  fi
+
+  echo "Could not determine OS platform."
+  echo "Please open a bug report for asdf-elm"
+  exit 1
+}
+
 
 get_download_url() {
   local install_type=$1
@@ -77,7 +101,12 @@ get_download_url() {
 
   if [ "$install_type" == "version" ]
   then
-    echo "https://dl.bintray.com/elmlang/elm-platform/$version/$(get_platform).tar.gz"
+    if [[ " $bintray_versions " =~ " $version " ]]
+    then
+      echo "https://dl.bintray.com/elmlang/elm-platform/$version/$(get_platform_pre_19).tar.gz"
+    else
+      echo "https://github.com/elm/compiler/releases/download/$version/binaries-for-$(get_platform_post_19).tar.gz"
+    fi
   else
     echo "asdf-elm: Can only install versioned binaries."
     echo "If you want to install another version from source, read:"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,27 +1,33 @@
 #!/usr/bin/env bash
+bintray_releases() {
+  releases_path=https://dl.bintray.com/elmlang/elm-platform/
+  cmd="curl -s"
 
-releases_path=https://dl.bintray.com/elmlang/elm-platform/
+  if [ -n "$GITHUB_API_TOKEN" ]; then
+    cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+  fi
 
-cmd="curl -s"
+  cmd="$cmd $releases_path"
 
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
+  sort_cmd='sort'
+  if sort --help | grep -q -- '-V'; then
+    sort_cmd='sort -V'
+  fi
 
-cmd="$cmd $releases_path"
+  # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
+  versions=$(eval $cmd | grep -oE ':[0-9\.]+(-\w+)?' | sed 's/://' | $sort_cmd)
 
-sort_cmd='sort'
-if sort --help | grep -q -- '-V'; then
-  sort_cmd='sort -V'
-fi
+  os=$(uname -s)
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE ':[0-9\.]+(-\w+)?' | sed 's/://' | $sort_cmd)
+  if [ "Linux" == "$os" ]; then
+    versions="$versions master"
+  fi
+  echo $versions
+}
 
-os=$(uname -s)
+github_releases() {
+  github_releases_path=https://api.github.com/repos/elm/compiler/releases
+  curl -s $github_releases_path | jq -r '.[] | .tag_name'
+}
 
-if [ "Linux" == "$os" ]; then
-  versions="$versions master"
-fi
-
-echo $versions
+echo $(bintray_releases) $(github_releases)


### PR DESCRIPTION
This provides support for Elm 0.19.0 where the release is hosted on Github.

It still fetches the previous releases from dl.bintray.com.