### PR TITLE
Fix sorting hiding versions by removing

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -27,10 +27,4 @@ elm_releases() {
   echo "$(bintray_releases) $(github_releases)"
 }
 
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-function sort_versions() {
-    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$//; G; s/\n/ /' | \
-        LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-echo $(elm_releases | sort_versions)
+echo $(elm_releases)


### PR DESCRIPTION
I think it's an issue, that `0.18.0` - the current previous and widely used version - is hidden in the list. I've no idea how the copied sort function is working, but right now it is swallowing the version, and that's a bug #6.

I suggest removing the sorting function for now.

Solves #6 

#### Update

I noticed the `asdf` guide suggests the sort implementation that is currently used. So maybe the issue should be mentioned there, too.

https://asdf-vm.com/#/plugins-create