### PR TITLE
Sort Github tags

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -20,7 +20,7 @@ github_releases() {
 
   cmd="$cmd $github_releases_path"
 
-  eval $cmd | grep -oE '\"tag_name\"\: \"(.*)\"' | cut -d: -f2 | tr -d '"'
+  eval $cmd | grep -oE '\"tag_name\"\: \"(.*)\"' | cut -d: -f2 | tr -d '"' | sort
 }
 
 elm_releases() {


### PR DESCRIPTION
Github returns releases with the latest first. This causes the order of
versions to be returned incorrectly. Sorting the tags from Github sets
the correct order when displaying all the versions.

**Current behavior:**
```
$ asdf list-all elm
0.15.1
0.16.0
0.16
0.17.0
0.17.1
0.18.0-alpha
0.18.0
0.19.1
0.19.0
```

**New behavior:**
```
$ asdf list-all elm
0.15.1
0.16.0
0.16
0.17.0
0.17.1
0.18.0-alpha
0.18.0
0.19.0
0.19.1
```