### PR TITLE
Add legacy files

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "elm-package.json elm.json"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo $(
+  cat $1 | grep -oiE '"elm-version": "([0-9\.]+)"' | grep -oE '[0-9\.]+'
+)


### PR DESCRIPTION
Some projects have a fixed elm version for those we can parse the
elm-package.json or elm.json and extract the version. Files with a
version range, e.g. '0.18.0 <= v < 0.19.0', are left alone.

I'm not the best with bash so this possibly could be made better. But, it's a start :).